### PR TITLE
Add in configuration

### DIFF
--- a/lib/templates/config.mustache
+++ b/lib/templates/config.mustache
@@ -1,0 +1,3 @@
+{
+	"sessionName": "{{sessionName}}"
+}

--- a/lib/templates/templates.rb
+++ b/lib/templates/templates.rb
@@ -5,11 +5,11 @@ module Templates
 		attr_accessor :object_states
 	end
 
-	Base.template_file = "lib/templates/base.mustache"
+	Base.template_file = File.join(__dir__, "base.mustache")
 
 	class Config < Mustache
 		attr_accessor :sessionName
 	end
 
-	Config.template_file = "lib/templates/config.mustache"
+	Config.template_file = File.join(__dir__, "config.mustache")
 end

--- a/lib/templates/templates.rb
+++ b/lib/templates/templates.rb
@@ -6,4 +6,10 @@ module Templates
 	end
 
 	Base.template_file = "lib/templates/base.mustache"
+
+	class Config < Mustache
+		attr_accessor :sessionName
+	end
+
+	Config.template_file = "lib/templates/config.mustache"
 end

--- a/lib/tts/commands.rb
+++ b/lib/tts/commands.rb
@@ -1,6 +1,7 @@
 require 'tts'
 require 'bundler/setup'
 require_relative '../templates/templates.rb'
+require_relative './file_repository.rb'
 
 module Tts
   TABLETOP_DIRECTORY_ENV_KEY = "TABLETOP_DIRECTORY"
@@ -18,6 +19,7 @@ module Tts
     end
 
     register :ImportMap, 'importMap', 'tts/commands/import/map'
+    register :Init, 'init', 'tts/commands/init'
     register :Help,    'help',    'tts/commands/help'
   end
 end

--- a/lib/tts/commands.rb
+++ b/lib/tts/commands.rb
@@ -1,11 +1,11 @@
 require 'tts'
 require 'bundler/setup'
 require_relative '../templates/templates.rb'
-require_relative './file_repository.rb'
+require_relative './session.rb'
+require_relative './saved_objects_storage.rb'
 
 module Tts
   TABLETOP_DIRECTORY_ENV_KEY = "TABLETOP_DIRECTORY"
-  SAVED_OBJECTS_DIRECTORY = "tts-cli"
 
   module Commands
     Registry = CLI::Kit::CommandRegistry.new(

--- a/lib/tts/commands/import/map.rb
+++ b/lib/tts/commands/import/map.rb
@@ -10,53 +10,56 @@ module Tts
       TILE_OBJECT_NAME = "Custom_Tile"
       SCALE = 0.99
       MAP_TAG = "map"
-      MAGIC_TEXT_CODE = "%99"
-
+      MAGIC_EMPTY_TEXT = "%99"
 
       def call(args, _name)
         tabletop_directory = ENV[Tts::TABLETOP_DIRECTORY_ENV_KEY]
         raise "You need to set the ENV key #{Tts::TABLETOP_DIRECTORY_ENV_KEY} with your tabletop saved objects folder" unless tabletop_directory
 
-        raise self.class.help unless args.length == 1
+        session_repo = SessionRepository.load_session!(Dir.pwd) 
 
-        map_raw_file_path = args[0] 
-        map_name = File.basename(map_raw_file_path).chomp(".csv")
+        puts session_repo.maps
 
-        map = Map.from_csv(map_raw_file_path)
+        session_repo.maps.each do |map_file_path|
+          puts "Importing #{map_file_path}..."
+          map_name = File.basename(map_file_path).chomp(".csv")
 
-        map_object = ::Templates::Base.new 
-        map_object.object_states = map.tiles.map.with_index do |tile_row, row_index|
-          tile_row.map.with_index do |tile, column_index|
-            next if tile.nil?
+          map = Map.from_csv(map_file_path)
 
-            {
-              object_name: TILE_OBJECT_NAME,
-              scale: SCALE, 
-              posX: x_position(column_index),
-              posZ: z_position(row_index),
-              nickname: tile.name,
-              description: tile.description || "",
-              notes: tile.notes || "",
-              tag: MAP_TAG, 
-              image_url: TILE_URL_TEMPLATE % { hex: tile.color[1..], text: MAGIC_TEXT_CODE },
-              back_url: TILE_BACK_URL 
-            }
-          end.compact
-        end.flatten
+          map_object = ::Templates::Base.new 
+          map_object.object_states = map.tiles.map.with_index do |tile_row, row_index|
+            tile_row.map.with_index do |tile, column_index|
+              next if tile.nil?
 
-        saved_object_content = map_object.render
+              {
+                object_name: TILE_OBJECT_NAME,
+                scale: SCALE, 
+                posX: x_position(column_index),
+                posZ: z_position(row_index),
+                nickname: tile.name,
+                description: tile.description || "",
+                notes: tile.notes || "",
+                tag: MAP_TAG, 
+                image_url: TILE_URL_TEMPLATE % { hex: tile.color[1..], text: MAGIC_EMPTY_TEXT },
+                back_url: TILE_BACK_URL 
+              }
+            end.compact
+          end.flatten
 
-        map_directory_path = File.join(tabletop_directory, Tts::SAVED_OBJECTS_DIRECTORY, MAP_DIRECTORY)
+          saved_object_content = map_object.render
 
-        FileUtils.mkdir_p(map_directory_path)
-        
-        map_file_path = File.join(map_directory_path, "#{map_name}.json")
+          map_directory_path = File.join(tabletop_directory, Tts::SAVED_OBJECTS_DIRECTORY, MAP_DIRECTORY)
 
-        File.write(map_file_path, saved_object_content)
+          FileUtils.mkdir_p(map_directory_path)
+          
+          map_file_path = File.join(map_directory_path, "#{map_name}.json")
+
+          File.write(map_file_path, saved_object_content)
+        end
       end
 
       def self.help
-        "Import a tile map file into Tabletop Simulator.\nUsage: {{command:#{Tts::TOOL_NAME} importMap path/to/map.csv}}"
+        "Import all tile map files in the current session directory into Tabletop Simulator.\nUsage: {{command:#{Tts::TOOL_NAME} importMap}}"
       end
 
       private

--- a/lib/tts/commands/init.rb
+++ b/lib/tts/commands/init.rb
@@ -1,0 +1,20 @@
+require 'tts'
+
+module Tts
+  module Commands
+    class Init < Tts::Command
+			def call(args, _name)
+				return self.help unless args.length == 1
+				name = args[0]
+
+				SessionRepository.create_session(name, name)
+
+				puts "Created session in #{name}. Change into the session directory to use import commands."
+			end
+
+			def self.help
+				"Initialize a new session directory. \nUsage: {{command:#{Tts::TOOL_NAME} init [session name]}}"
+			end
+		end
+	end
+end

--- a/lib/tts/commands/init.rb
+++ b/lib/tts/commands/init.rb
@@ -7,7 +7,7 @@ module Tts
 				return self.help unless args.length == 1
 				name = args[0]
 
-				SessionRepository.create_session(name, name)
+				Session.build(name, name)
 
 				puts "Created session in #{name}. Change into the session directory to use import commands."
 			end

--- a/lib/tts/file_repository.rb
+++ b/lib/tts/file_repository.rb
@@ -1,0 +1,44 @@
+module Tts
+	class SessionRepository
+		def initialize(path)
+			@path = path
+		end
+
+		def self.load_session!(path)
+			repo = new(path)
+
+			unless File.exists?(repo.config_path)
+				raise "No config file found at #{repo.config_path}. Create a session with the `init` command and cd into it."
+			end
+
+		  repo	
+		end
+
+		def self.create_session(path, name)
+			repo = new(path)
+
+			config = Templates::Config.new
+			config.sessionName = name 
+
+			FileUtils.mkdir_p(repo.map_directory_path)
+			File.write(repo.config_path, config.render)
+		end
+
+		def maps
+			(Dir.entries(map_directory_path) - ['.','..']).map do |entry|
+				File.join(map_directory_path, entry)
+			end
+		end
+
+		def config_path
+			File.join(@path, 'config.json')
+		end
+
+		def map_directory_path
+			File.join(@path, 'maps')
+		end
+
+		private
+
+	end
+end

--- a/lib/tts/saved_objects_storage.rb
+++ b/lib/tts/saved_objects_storage.rb
@@ -1,0 +1,31 @@
+module Tts
+	class SavedObjectsStorage
+		MAP_DIRECTORY = "maps"
+		BASE_DIRECTORY = "tts-cli"
+
+		def initialize(tts_directory, session)
+			@tts_directory = tts_directory
+			@session = session
+		end
+
+		def save_map(map, name)
+			map_directory_path = File.join(session_path, MAP_DIRECTORY)
+
+			FileUtils.mkdir_p(map_directory_path)
+			
+			map_file_path = File.join(map_directory_path, "#{name}.json")
+
+			File.write(map_file_path, map)
+		end
+
+		private
+
+		def session_path
+			File.join(base_path, @session.name)
+		end
+
+		def base_path
+			File.join(@tts_directory, BASE_DIRECTORY)
+		end
+	end
+end

--- a/lib/tts/session.rb
+++ b/lib/tts/session.rb
@@ -1,20 +1,22 @@
+require "json"
+
 module Tts
-	class SessionRepository
+	class Session
 		def initialize(path)
 			@path = path
 		end
 
-		def self.load_session!(path)
-			repo = new(path)
+		def self.load!(path)
+			session = new(path)
 
-			unless File.exists?(repo.config_path)
-				raise "No config file found at #{repo.config_path}. Create a session with the `init` command and cd into it."
+			unless File.exists?(session.config_path)
+				raise "No config file found at #{session.config_path}. Create a session with the `init` command and cd into it."
 			end
 
-		  repo	
+		  session	
 		end
 
-		def self.create_session(path, name)
+		def self.build(path, name)
 			repo = new(path)
 
 			config = Templates::Config.new
@@ -30,6 +32,14 @@ module Tts
 			end
 		end
 
+		def config
+			@config ||= JSON.parse(File.read(config_path))
+		end
+
+		def name
+			config["sessionName"]
+		end
+
 		def config_path
 			File.join(@path, 'config.json')
 		end
@@ -37,8 +47,5 @@ module Tts
 		def map_directory_path
 			File.join(@path, 'maps')
 		end
-
-		private
-
 	end
 end


### PR DESCRIPTION
Adds the notion of a Session, which refers to a directory that contains all the different importable objects. The assumption is that the user will be working on one session at a time, and that assets will be predominantly distinct between them.

A command `init` was created to create one of these directories along with necessary folders.

Future commands will assume that the user is chdir'd into a session directory.

Built a class which isolates the behaviour of writing into the saved objects directory. The file structure is as follows:
```
[saved objects directory]/[session name as stored in the config.json]/[object category name, e.g. Maps]
```